### PR TITLE
LIBHYDRA-46. Use environment variables for fcrepo and iiif server url.

### DIFF
--- a/files/fcrepo-search.env
+++ b/files/fcrepo-search.env
@@ -2,3 +2,9 @@
 
 # URL of the solr running in the fcrepo-vagrant
 SOLR_URL=http://192.168.40.11:8983/solr/fedora4
+
+# URL of the fcrepo running in the fcrepo-vagrant
+FCREPO_BASE_URL=https://fcrepolocal/fcrepo/rest/
+
+# URL of the pcdm-manifest running in the iiif-vagrant
+IIIF_MANIFEST_URL=https://iiiflocal/manifests/


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBHYDRA-46