### PR TITLE
LIBHYDRA-56. Use private IP of 192.168.40.14.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ server if necessary.
 **Warning:** Without a working solr url, the fcrepo-search will not function.
 
 ### fcrepo-search 
-The [fcrepo-search][2] repo will be automatically checked into the host machine, if the 
+The [fcrepo-search][2] repo will be automatically checked out onto the host machine, if the 
 vagrant finds that the `/apps/git/fcrepo-search` directory does not exist when you 
 run `vagrant up` 
 
@@ -27,7 +27,7 @@ run `vagrant up`
 > vagrant up
 ```
 
-You should be able to access the fcrepo-search app at [http://localhost:8000/][3]
+You should be able to access the fcrepo-search app at <http://192.168.44.14>.
 
 ## Details
 
@@ -38,11 +38,9 @@ Base box: [peichman-umd/ruby (1.0.0)][4] with:
 * Ruby 2.2.4
 * Rails 4.2.6
 
-Port 80 on the guest is forwarded to 8000 on the host.
-
 Installs the most recent version of [Phusion Passenger][5] (5.0.26 as of March
 29, 2016). Configures Apache with mod_passenger to serve the Rails app found in
-`/apps/src` on port 80.
+`/apps/services/fcrepo-search` on port 80.
 
 Also [installs NodeJS and NPM][6], for compiling Javascript resources in Rails'
 asset pipeline. This relieves the need for the Rails app to include "therubyracer"
@@ -50,7 +48,6 @@ or similar gems in its Gemfile.
 
 [1]: https://github.com//umd-lib/fcrepo-vagrant
 [2]: https://github.com//umd-lib/fcrepo-search
-[3]: http://localhost:8000/
 [4]: https://atlas.hashicorp.com/peichman-umd/boxes/ruby/versions/1.0.0
 [5]: https://www.phusionpassenger.com/
 [6]: https://www.phusionpassenger.com/library/walkthroughs/deploy/ruby/ownserver/apache/oss/install_language_runtime.html#optional-install-node-js-if-you-re-using-rails

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,17 +11,16 @@ Vagrant.configure(2) do |config|
 
   config.vm.box = "peichman-umd/ruby"
 
-  config.vm.network "forwarded_port", guest: 80, host: 8000
-
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.40.14"
 
   config.vm.synced_folder "/apps/git/fcrepo-search", "/apps/services/fcrepo-search"
 
-  config.vm.provision "shell", inline: "yum -y install git"
+  # system packages
+  config.vm.provision 'puppet'
 
+  config.vm.provision 'shell', path: 'scripts/openports.sh', args: [80]
   config.vm.provision "shell", path: "scripts/passenger.sh", privileged: true
   config.vm.provision "shell", path: "scripts/nodejs.sh", privileged: true
-  config.vm.provision "shell", path: "scripts/firewall.sh", privileged: true
   config.vm.provision "file", source: 'files/fcrepo-search.env', destination: '/apps/services/fcrepo-search/.env'
   config.vm.provision "file", source: 'files/seeds.rb', destination: '/apps/services/fcrepo-search/db/seeds/vagrant.rb'
   config.vm.provision "shell", path: "scripts/railsapp.sh", privileged: false

--- a/files/fcrepo-search.env
+++ b/files/fcrepo-search.env
@@ -1,7 +1,7 @@
 # Enviroment variables for the fcrepo-search webapp
 
 # URL of the solr running in the fcrepo-vagrant
-SOLR_URL=http://192.168.40.11:8983/solr/fedora4
+SOLR_URL=http://solrlocal:8983/solr/fedora4
 
 # URL of the fcrepo running in the fcrepo-vagrant
 FCREPO_BASE_URL=https://fcrepolocal/fcrepo/rest/

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -1,0 +1,11 @@
+Package {
+  allow_virtual => false,
+}
+
+package { "git":
+  ensure => present,
+}
+
+host { "solrlocal":
+  ip => "192.168.40.11",
+}

--- a/scripts/firewall.sh
+++ b/scripts/firewall.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# add to permanent rules
-# 80: default HTTP port
-firewall-cmd --zone=public --add-port=80/tcp --permanent
-
-# reload the firewall to make the changes take effect
-firewall-cmd --reload

--- a/scripts/openports.sh
+++ b/scripts/openports.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for port in "$@"; do
+    firewall-cmd --zone=public --add-port="$port"/tcp --permanent
+done
+
+if [ $# -gt 0 ]; then
+    firewall-cmd --reload
+fi


### PR DESCRIPTION
* Use Puppet to install git and configure hosts file.
* Use "solrlocal" instead of "192.168.40.11" in Rails app config.
* Switch to the "openports.sh" script that takes arguments for ports to open.
* Updated README

https://issues.umd.edu/browse/LIBHYDRA-56