### PR TITLE
LIBHYDRA-62. Create self-signed SSL certs in Vagrant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vagrant/
 .env
+dist/ssl/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.synced_folder "/apps/git/archelon-env", "/apps/git/archelon-env"
   config.vm.synced_folder "/apps/git/archelon", "/apps/archelon/src"
+  config.vm.synced_folder "dist", "/apps/dist"
 
   # system packages
   config.vm.provision 'puppet'
@@ -28,9 +29,11 @@ Vagrant.configure(2) do |config|
   config.vm.provision 'shell', path: 'scripts/env.sh'
 
   # firewall
-  config.vm.provision 'shell', path: 'scripts/openports.sh', args: [80]
+  config.vm.provision 'shell', path: 'scripts/openports.sh', args: [80, 443]
   # Apache configuration
   config.vm.provision 'shell', path: 'scripts/apache.sh'
+  # create self-signed certificate for Apache
+  config.vm.provision "shell", path: "scripts/https-cert.sh"
   # mod_passenger
   config.vm.provision "shell", path: "scripts/passenger.sh"
   # Rails app config

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,5 @@
+# archelon-vagrant/dist
+
+This is the directory that holds the distribution archives for some of the
+applications needed to run the Archelon application. See [the main README](../README.md) for
+more information.

--- a/files/archelon.env
+++ b/files/archelon.env
@@ -1,7 +1,7 @@
 # Enviroment variables for the fcrepo-search webapp
 
 # URL of the solr running in the fcrepo-vagrant
-SOLR_URL=http://solrlocal:8983/solr/fedora4
+SOLR_URL=https://solrlocal:8984/solr/fedora4
 
 # URL of the fcrepo running in the fcrepo-vagrant
 FCREPO_BASE_URL=https://fcrepolocal/fcrepo/rest/

--- a/files/env
+++ b/files/env
@@ -11,3 +11,8 @@ export SERVICE_GROUP=vagrant
 export SSL_CERT_NAME=archelonlocal.crt
 export SSL_CERT_CHAIN_FILE_NAME=
 export SSL_KEY_NAME=archelonlocal.key
+
+# set trusted SSL certificates for Archelon's HTTPS connections
+# this is only needed for archelonlocal
+# must set this here and not in Archelon's .env file for some reason
+export SSL_CERT_FILE=/apps/archelon/ssl/solrlocal.pem

--- a/files/env
+++ b/files/env
@@ -3,5 +3,11 @@
 # SERVER ENVIRONMENT
 
 export SERVER_NAME=archelonlocal
+export IP_ADDRESS=192.168.40.14
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
+
+# Apache variables
+export SSL_CERT_NAME=archelonlocal.crt
+export SSL_CERT_CHAIN_FILE_NAME=
+export SSL_KEY_NAME=archelonlocal.key

--- a/scripts/host-prereqs.sh
+++ b/scripts/host-prereqs.sh
@@ -27,7 +27,7 @@ echo "2. Ensure archelon app exists."
 ensure_git_repo /apps/git/archelon git@github.com:umd-lib/archelon.git || exit 1
 
 echo "3. Ensure solr is running"
-SOLR_STATUS_URL="http://192.168.40.11:8983/solr/admin/cores?action=STATUS&core=fedora4"
+SOLR_STATUS_URL="https://192.168.40.11:8984/solr/admin/cores?action=STATUS&core=fedora4"
 
 status=$(curl -k $SOLR_STATUS_URL -s -w "%{http_code}" -o /dev/null)
 

--- a/scripts/https-cert.sh
+++ b/scripts/https-cert.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+HOSTNAME=archelonlocal
+IP_ADDRESS=192.168.40.14
+
+CACHED_SSL_CONF=/apps/dist/ssl
+
+if [ -e "$CACHED_SSL_CONF" ]; then
+    echo "Using HTTPS SSL configuration cached in dist/ssl"
+    cp -rp /apps/dist/ssl /apps
+else
+    # SSL Certificate (self-signed)
+    mkdir -p /apps/ssl/{key,csr,cert,cnf}
+
+    KEY=/apps/ssl/key/${HOSTNAME}.key
+    CSR=/apps/ssl/csr/${HOSTNAME}.csr
+    CRT=/apps/ssl/cert/${HOSTNAME}.crt
+    CNF=/apps/ssl/cnf/${HOSTNAME}.cnf
+
+    cat > "$CNF" <<END
+[ req ]
+prompt             = no
+distinguished_name = ${HOSTNAME}_dn
+req_extensions     = v3_req
+
+[ ${HOSTNAME}_dn ]
+commonName              = ${HOSTNAME}
+stateOrProvinceName     = MD
+countryName             = US
+organizationName        = UMD
+organizationalUnitName  = Libraries
+
+[ v3_req ]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = ${HOSTNAME}
+DNS.2 = localhost
+IP.1  = ${IP_ADDRESS}
+IP.2  = 127.0.0.1
+END
+
+    # Generate private key 
+    openssl genrsa -out "$KEY" 2048
+
+    # Generate CSR 
+    openssl req -new -key "$KEY" -out "$CSR" -config "$CNF"
+
+    # Generate self-signed cert
+    openssl x509 -req -days 365 -in "$CSR" -signkey "$KEY" -out "$CRT" \
+        -extensions v3_req -extfile "$CNF"
+
+    # cache the SSL cert info for the next run of Vagrant
+    cp -rp /apps/ssl /apps/dist
+fi

--- a/scripts/railsapp.sh
+++ b/scripts/railsapp.sh
@@ -6,3 +6,10 @@ gem install bundler
 bundle install
 bin/rake db:migrate RAILS_ENV=vagrant
 bin/rake db:seed RAILS_ENV=vagrant
+
+# get self-signed cert from solrlocal
+mkdir -p /apps/archelon/ssl
+echo -n \
+    | openssl s_client -connect solrlocal:8984 \
+    | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' \
+    > /apps/archelon/ssl/solrlocal.pem


### PR DESCRIPTION
Cache in the dist/ssl directory between runs.

https://issues.umd.edu/browse/LIBHYDRA-62