### PR TITLE
LIBHYDRA-121. Fix mod_passenger failure to install.

### DIFF
--- a/scripts/passenger.sh
+++ b/scripts/passenger.sh
@@ -2,6 +2,6 @@
 
 # https://www.phusionpassenger.com/library/walkthroughs/deploy/ruby/ownserver/apache/oss/el7/install_passenger.html
 
-curl --fail -sSLo /etc/yum.repos.d/passenger.repo \
-  https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo
-yum install -y mod_passenger
+yum install -y httpd epel-release pygpgme curl nss
+REPO_URL=https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo
+curl --fail -sSLo /etc/yum.repos.d/passenger.repo "$REPO_URL" && yum install -y mod_passenger


### PR DESCRIPTION
Borrowed the script from the iiif-vagrant, that makes sure to install the latest version of nss (required for cert verification with the passenger yum repo).

https://issues.umd.edu/browse/LIBHYDRA-121