### PR TITLE
LIBHYDRA-113. HTTPS configuration for downloads host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,22 @@ run `vagrant up`
 > vagrant up
 ```
 
-You should be able to access the Archelon app at <http://192.168.44.14>.
+Create a user account using a Rake task:
+
+```
+> vagrant ssh
+> cd /apps/archelon/src
+> rake 'db:add_admin_cas_user[your_directory_id, Your Name]' RAILS_ENV=vagrant
+```
+
+For full access to all features, add the hostnames `archelonlocal` and 
+`downloadslocal` to your host machine's `/etc/hosts` file:
+
+```
+192.168.40.14 archelonlocal downloadslocal
+```
+
+You should now be able to access the Archelon app at <https://archelonlocal>
 
 ## Details
 

--- a/files/archelon.env
+++ b/files/archelon.env
@@ -8,3 +8,6 @@ FCREPO_BASE_URL=https://fcrepolocal/fcrepo/rest/
 
 # URL of the pcdm-manifest running in the iiif-vagrant
 IIIF_MANIFEST_URL=https://iiiflocal/manifests/
+
+# base URL for file downloads
+RETRIEVE_BASE_URL=https://downloadslocal/

--- a/files/env
+++ b/files/env
@@ -3,6 +3,7 @@
 # SERVER ENVIRONMENT
 
 export SERVER_NAME=archelonlocal
+export DOWNLOADS_SERVER_NAME=downloadslocal
 export IP_ADDRESS=192.168.40.14
 export SERVICE_USER=vagrant
 export SERVICE_GROUP=vagrant
@@ -15,4 +16,4 @@ export SSL_KEY_NAME=archelonlocal.key
 # set trusted SSL certificates for Archelon's HTTPS connections
 # this is only needed for archelonlocal
 # must set this here and not in Archelon's .env file for some reason
-export SSL_CERT_FILE=/apps/archelon/ssl/solrlocal.pem
+export SSL_CERT_FILE=/apps/archelon/ssl/localcerts.pem

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -15,6 +15,12 @@ package { "git":
   ensure => present,
 }
 
+host { "fcrepolocal":
+  ip => "192.168.40.10",
+}
 host { "solrlocal":
   ip => "192.168.40.11",
+}
+host { "archelonlocal":
+  ip => "192.168.40.14",
 }

--- a/scripts/https-cert.sh
+++ b/scripts/https-cert.sh
@@ -36,6 +36,7 @@ subjectAltName = @alt_names
 [alt_names]
 DNS.1 = ${HOSTNAME}
 DNS.2 = localhost
+DNS.3 = downloadslocal
 IP.1  = ${IP_ADDRESS}
 IP.2  = 127.0.0.1
 END

--- a/scripts/railsapp.sh
+++ b/scripts/railsapp.sh
@@ -7,9 +7,16 @@ bundle install
 bin/rake db:migrate RAILS_ENV=vagrant
 bin/rake db:seed RAILS_ENV=vagrant
 
-# get self-signed cert from solrlocal
 mkdir -p /apps/archelon/ssl
+
+# get self-signed cert from solrlocal
 echo -n \
     | openssl s_client -connect solrlocal:8984 \
     | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' \
-    > /apps/archelon/ssl/solrlocal.pem
+    >> /apps/archelon/ssl/localcerts.pem
+
+# get self-signed cert from fcrepolocal
+echo -n \
+    | openssl s_client -connect fcrepolocal:443 \
+    | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' \
+    >> /apps/archelon/ssl/localcerts.pem


### PR DESCRIPTION
* Add fcrepolocal and archelonlocal to hosts file
* Add the fcrepolocal self-signed certificate to the local certs PEM file that is used by Archelon for SSL verification.
* Add "downloadslocal" as a SAN to the Apache HTTPS cert

https://issues.umd.edu/browse/LIBHYDRA-113